### PR TITLE
add environment.yml for binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,21 @@
+channels:
+  - conda-forge
+dependencies:
+  - python
+  - pydensecrf
+  - cython
+  - numpy
+  - scipy
+  - matplotlib
+  - scikit-image
+  - scikit-learn
+  - joblib
+  - tensorflow
+  - opencv
+  - ipython
+  - tensorflow-hub
+  - jupyter
+  - tqdm
+  - s3fs
+  - gdal
+  - rasterio


### PR DESCRIPTION
This allows the cdi_dl_workshop to run on binder, for example:
http://binder.pangeo.io/v2/gh/rsignell-usgs/cdi_dl_workshop.git/patch-1?filepath=Day1%2F1.8.Intro_tensorflow.ipynb
